### PR TITLE
fix cmake inclusion and install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,16 +74,20 @@ IF(${CMAKE_VERSION} VERSION_LESS "3.0")
 ELSE()
   ADD_LIBRARY(fp16 INTERFACE)
 ENDIF()
-TARGET_INCLUDE_DIRECTORIES(fp16 INTERFACE include)
+TARGET_INCLUDE_DIRECTORIES(fp16 INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>)
 
 INSTALL(FILES include/fp16.h
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+INSTALL(FILES
     include/fp16/bitcasts.h
     include/fp16/fp16.h
     include/fp16/psimd.h
     include/fp16/__init__.py
     include/fp16/avx.py
     include/fp16/avx2.py
-  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/fp16)
 
 # ---[ Configure psimd
 IF(NOT TARGET psimd)


### PR DESCRIPTION
For target include directories, one need to set build and install separately to be safer. For installation, the previous installation is actually incorrect because the INSTALL(FILES ...) will remove the folder structure. Given we only have 2 folders, I made it so that we manually put fp16 in root and everything else in a separate fp16 folder.