### PR TITLE
Update the dependent libraries downloading path.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,39 +28,34 @@ MACRO(FP16_TARGET_ENABLE_CXX11 target)
 ENDMACRO()
 
 # ---[ Download deps
-SET(CONFU_DEPENDENCIES_SOURCE_DIR ${CMAKE_SOURCE_DIR}/deps
-  CACHE PATH "Confu-style dependencies source directory")
-SET(CONFU_DEPENDENCIES_BINARY_DIR ${CMAKE_BINARY_DIR}/deps
-  CACHE PATH "Confu-style dependencies binary directory")
-
 IF(NOT DEFINED PSIMD_SOURCE_DIR)
-  MESSAGE(STATUS "Downloading PSimd to ${CONFU_DEPENDENCIES_SOURCE_DIR}/psimd (define PSIMD_SOURCE_DIR to avoid it)")
-  CONFIGURE_FILE(cmake/DownloadPSimd.cmake "${CONFU_DEPENDENCIES_BINARY_DIR}/psimd-download/CMakeLists.txt")
+  MESSAGE(STATUS "Downloading PSimd to ${CMAKE_BINARY_DIR}/psimd-source (define PSIMD_SOURCE_DIR to avoid it)")
+  CONFIGURE_FILE(cmake/DownloadPSimd.cmake "${CMAKE_BINARY_DIR}/psimd-download/CMakeLists.txt")
   EXECUTE_PROCESS(COMMAND "${CMAKE_COMMAND}" -G "${CMAKE_GENERATOR}" .
-    WORKING_DIRECTORY "${CONFU_DEPENDENCIES_BINARY_DIR}/psimd-download")
+    WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/psimd-download")
   EXECUTE_PROCESS(COMMAND "${CMAKE_COMMAND}" --build .
-    WORKING_DIRECTORY "${CONFU_DEPENDENCIES_BINARY_DIR}/psimd-download")
-  SET(PSIMD_SOURCE_DIR "${CONFU_DEPENDENCIES_SOURCE_DIR}/psimd" CACHE STRING "PSimd source directory")
+    WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/psimd-download")
+  SET(PSIMD_SOURCE_DIR "${CMAKE_BINARY_DIR}/psimd-source" CACHE STRING "PSimd source directory")
 ENDIF()
 
 IF(FP16_BUILD_TESTS AND NOT DEFINED GOOGLETEST_SOURCE_DIR)
-  MESSAGE(STATUS "Downloading Google Test to ${CONFU_DEPENDENCIES_SOURCE_DIR}/googletest (define GOOGLETEST_SOURCE_DIR to avoid it)")
-  CONFIGURE_FILE(cmake/DownloadGoogleTest.cmake "${CONFU_DEPENDENCIES_BINARY_DIR}/googletest-download/CMakeLists.txt")
+  MESSAGE(STATUS "Downloading Google Test to ${CMAKE_BINARY_DIR}/googletest-source (define GOOGLETEST_SOURCE_DIR to avoid it)")
+  CONFIGURE_FILE(cmake/DownloadGoogleTest.cmake "${CMAKE_BINARY_DIR}/googletest-download/CMakeLists.txt")
   EXECUTE_PROCESS(COMMAND "${CMAKE_COMMAND}" -G "${CMAKE_GENERATOR}" .
-    WORKING_DIRECTORY "${CONFU_DEPENDENCIES_BINARY_DIR}/googletest-download")
+    WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/googletest-download")
   EXECUTE_PROCESS(COMMAND "${CMAKE_COMMAND}" --build .
-    WORKING_DIRECTORY "${CONFU_DEPENDENCIES_BINARY_DIR}/googletest-download")
-  SET(GOOGLETEST_SOURCE_DIR "${CONFU_DEPENDENCIES_SOURCE_DIR}/googletest" CACHE STRING "Google Test source directory")
+    WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/googletest-download")
+  SET(GOOGLETEST_SOURCE_DIR "${CMAKE_BINARY_DIR}/googletest-source" CACHE STRING "Google Test source directory")
 ENDIF()
 
 IF(FP16_BUILD_BENCHMARKS AND NOT DEFINED GOOGLEBENCHMARK_SOURCE_DIR)
-  MESSAGE(STATUS "Downloading Google Benchmark to ${CONFU_DEPENDENCIES_SOURCE_DIR}/googlebenchmark (define GOOGLEBENCHMARK_SOURCE_DIR to avoid it)")
-  CONFIGURE_FILE(cmake/DownloadGoogleBenchmark.cmake "${CONFU_DEPENDENCIES_BINARY_DIR}/googlebenchmark-download/CMakeLists.txt")
+  MESSAGE(STATUS "Downloading Google Benchmark to ${CMAKE_BINARY_DIR}/googlebenchmark-source (define GOOGLEBENCHMARK_SOURCE_DIR to avoid it)")
+  CONFIGURE_FILE(cmake/DownloadGoogleBenchmark.cmake "${CMAKE_BINARY_DIR}/googlebenchmark-download/CMakeLists.txt")
   EXECUTE_PROCESS(COMMAND "${CMAKE_COMMAND}" -G "${CMAKE_GENERATOR}" .
-    WORKING_DIRECTORY "${CONFU_DEPENDENCIES_BINARY_DIR}/googlebenchmark-download")
+    WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/googlebenchmark-download")
   EXECUTE_PROCESS(COMMAND "${CMAKE_COMMAND}" --build .
-    WORKING_DIRECTORY "${CONFU_DEPENDENCIES_BINARY_DIR}/googlebenchmark-download")
-  SET(GOOGLEBENCHMARK_SOURCE_DIR "${CONFU_DEPENDENCIES_SOURCE_DIR}/googlebenchmark" CACHE STRING "Google Benchmark source directory")
+    WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/googlebenchmark-download")
+  SET(GOOGLEBENCHMARK_SOURCE_DIR "${CMAKE_BINARY_DIR}/googlebenchmark-source" CACHE STRING "Google Benchmark source directory")
 ENDIF()
 
 # ---[ FP16 library
@@ -93,7 +88,7 @@ INSTALL(FILES
 IF(NOT TARGET psimd)
   ADD_SUBDIRECTORY(
     "${PSIMD_SOURCE_DIR}"
-    "${CONFU_DEPENDENCIES_BINARY_DIR}/psimd")
+    "${CMAKE_BINARY_DIR}/psimd")
 ENDIF()
 
 IF(FP16_BUILD_TESTS)
@@ -102,7 +97,7 @@ IF(FP16_BUILD_TESTS)
     SET(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
     ADD_SUBDIRECTORY(
       "${GOOGLETEST_SOURCE_DIR}"
-      "${CONFU_DEPENDENCIES_BINARY_DIR}/googletest")
+      "${CMAKE_BINARY_DIR}/googletest")
   ENDIF()
 
   # ---[ Build FP16 unit tests
@@ -147,7 +142,7 @@ IF(FP16_BUILD_BENCHMARKS)
     SET(BENCHMARK_ENABLE_TESTING OFF CACHE BOOL "")
     ADD_SUBDIRECTORY(
       "${GOOGLEBENCHMARK_SOURCE_DIR}"
-      "${CONFU_DEPENDENCIES_BINARY_DIR}/googlebenchmark")
+      "${CMAKE_BINARY_DIR}/googlebenchmark")
   ENDIF()
 
   # ---[ Build FP16 benchmarks

--- a/cmake/DownloadGoogleBenchmark.cmake
+++ b/cmake/DownloadGoogleBenchmark.cmake
@@ -6,8 +6,8 @@ INCLUDE(ExternalProject)
 ExternalProject_Add(googlebenchmark
 	URL https://github.com/google/benchmark/archive/v1.2.0.zip
 	URL_HASH SHA256=cc463b28cb3701a35c0855fbcefb75b29068443f1952b64dd5f4f669272e95ea
-	SOURCE_DIR "${CONFU_DEPENDENCIES_SOURCE_DIR}/googlebenchmark"
-	BINARY_DIR "${CONFU_DEPENDENCIES_BINARY_DIR}/googlebenchmark"
+	SOURCE_DIR "${CMAKE_BINARY_DIR}/googlebenchmark-source"
+	BINARY_DIR "${CMAKE_BINARY_DIR}/googlebenchmark"
 	CONFIGURE_COMMAND ""
 	BUILD_COMMAND ""
 	INSTALL_COMMAND ""

--- a/cmake/DownloadGoogleTest.cmake
+++ b/cmake/DownloadGoogleTest.cmake
@@ -6,8 +6,8 @@ INCLUDE(ExternalProject)
 ExternalProject_Add(googletest
 	URL https://github.com/google/googletest/archive/release-1.8.0.zip
 	URL_HASH SHA256=f3ed3b58511efd272eb074a3a6d6fb79d7c2e6a0e374323d1e6bcbcc1ef141bf
-	SOURCE_DIR "${CONFU_DEPENDENCIES_SOURCE_DIR}/googletest"
-	BINARY_DIR "${CONFU_DEPENDENCIES_BINARY_DIR}/googletest"
+	SOURCE_DIR "${CMAKE_BINARY_DIR}/googletest-source"
+	BINARY_DIR "${CMAKE_BINARY_DIR}/googletest"
 	CONFIGURE_COMMAND ""
 	BUILD_COMMAND ""
 	INSTALL_COMMAND ""

--- a/cmake/DownloadPSimd.cmake
+++ b/cmake/DownloadPSimd.cmake
@@ -6,8 +6,8 @@ INCLUDE(ExternalProject)
 ExternalProject_Add(psimd
 	GIT_REPOSITORY https://github.com/Maratyszcza/psimd.git
 	GIT_TAG master
-	SOURCE_DIR "${CONFU_DEPENDENCIES_SOURCE_DIR}/psimd"
-	BINARY_DIR "${CONFU_DEPENDENCIES_BINARY_DIR}/psimd"
+	SOURCE_DIR "${CMAKE_BINARY_DIR}/psimd-source"
+	BINARY_DIR "${CMAKE_BINARY_DIR}/psimd"
 	CONFIGURE_COMMAND ""
 	BUILD_COMMAND ""
 	INSTALL_COMMAND ""


### PR DESCRIPTION
The dependent libraries will be downloaded into the source tree if we use CMAKE_SOURCE_DIR.
Change to use CMAKE_BINARY_DIR instead.