### PR TITLE
Removed extra semicolon at the end of a function

### DIFF
--- a/third-party/half.hpp
+++ b/third-party/half.hpp
@@ -1922,7 +1922,7 @@ namespace half_float
 		#endif
 
 			typedef half type;
-			static half cast(U arg) { return cast_impl(arg, is_float<U>()); };
+			static half cast(U arg) { return cast_impl(arg, is_float<U>()); }
 
 		private:
 			static half cast_impl(U arg, true_type) { return half(binary, float2half<R>(static_cast<float>(arg))); }


### PR DESCRIPTION
There is an extra semicolon at the end of [L1925](https://github.com/Maratyszcza/FP16/blob/master/third-party/half.hpp#L1925), and we met this bug when developing WebNN in chromium: [CL 5378104](https://chromium-review.googlesource.com/c/chromium/src/+/5378104/comment/dd75038c_48aac532/).
The [error logs](https://ci.chromium.org/ui/p/chromium/builders/try/win-rel/559535/overview) are as following:
```
CXX obj/components/ml/webnn/webnn/graph_validation_utils.obj
../../third_party/llvm-build/Release+Asserts/bin/clang-cl.exe /c ../../components/ml/webnn/graph_val...(too long)
In file included from ../../components/ml/webnn/graph_validation_utils.cc:20:
../..\third_party/fp16/src/third-party/half.hpp(1925,69): error: extra ';' after member function definition [-Werror,-Wextra-semi]
 1925 |                         static half cast(U arg) { return cast_impl(arg, is_float<U>()); };
      |                                                                                          ^
1 error generated.
Note: including file: ../..\components/ml/webnn/graph_validation_utils.h
```
This PR removed the extra semicolon and please take a look, thanks! @Maratyszcza @robertogden@chromium.org