### PR TITLE
Fix compiling intrinsics with MSVC.

### DIFF
--- a/include/fp16/bitcasts.h
+++ b/include/fp16/bitcasts.h
@@ -8,7 +8,7 @@
 	#include <stdint.h>
 #endif
 
-#if defined(__INTEL_COMPILER)
+#if defined(__INTEL_COMPILER) || defined(_MSC_VER) && (_MSC_VER >= 1932) && (defined(_M_IX86) || defined(_M_X64))
 	#include <immintrin.h>
 #endif
 


### PR DESCRIPTION
Fixes the error `error C3861: '_castu32_f32': identifier not found`.

Fixes #30