### PR TITLE
Add missing standard lib includes to tests

### DIFF
--- a/test/alt-from-fp32-value.cc
+++ b/test/alt-from-fp32-value.cc
@@ -1,6 +1,8 @@
 #include <gtest/gtest.h>
 
 #include <cstdint>
+#include <iomanip>
+#include <ios>
 
 #include <fp16.h>
 #include <tables.h>

--- a/test/alt-to-fp32-bits.cc
+++ b/test/alt-to-fp32-bits.cc
@@ -1,6 +1,8 @@
 #include <gtest/gtest.h>
 
 #include <cstdint>
+#include <iomanip>
+#include <ios>
 
 #include <fp16.h>
 #include <tables.h>

--- a/test/alt-to-fp32-value.cc
+++ b/test/alt-to-fp32-value.cc
@@ -2,6 +2,8 @@
 
 #include <cstdint>
 #include <cmath>
+#include <iomanip>
+#include <ios>
 
 #include <fp16.h>
 #include <tables.h>

--- a/test/bitcasts.cc
+++ b/test/bitcasts.cc
@@ -1,6 +1,8 @@
 #include <gtest/gtest.h>
 
 #include <cstdint>
+#include <iomanip>
+#include <ios>
 
 #include <fp16.h>
 

--- a/test/ieee-from-fp32-value.cc
+++ b/test/ieee-from-fp32-value.cc
@@ -1,6 +1,8 @@
 #include <gtest/gtest.h>
 
 #include <cstdint>
+#include <iomanip>
+#include <ios>
 
 #include <fp16.h>
 #include <tables.h>

--- a/test/ieee-to-fp32-bits.cc
+++ b/test/ieee-to-fp32-bits.cc
@@ -1,6 +1,8 @@
 #include <gtest/gtest.h>
 
 #include <cstdint>
+#include <iomanip>
+#include <ios>
 
 #include <fp16.h>
 #include <tables.h>

--- a/test/ieee-to-fp32-value.cc
+++ b/test/ieee-to-fp32-value.cc
@@ -2,6 +2,8 @@
 
 #include <cstdint>
 #include <cmath>
+#include <iomanip>
+#include <ios>
 
 #include <fp16.h>
 #include <tables.h>


### PR DESCRIPTION
The tests were using std::setw, std::hex, etc. without including the relevant standard library headers. This worked because of transitive includes from googletest, but that's not something we should rely on:
1. In general it's considered a bad practice
2. Whenever we want to upgrade our googletest dependency this is going to be a blocker