### PR TITLE
Fix compilation of bitcasts with clang on x86

### DIFF
--- a/include/fp16/bitcasts.h
+++ b/include/fp16/bitcasts.h
@@ -16,6 +16,10 @@
 	#include <intrin.h>
 #endif
 
+#if defined(__clang__) && (defined(_M_IX86) || defined(_M_X64))
+   #include <x86intrin.h>
+#endif
+
 
 static inline float fp32_from_bits(uint32_t w) {
 #if defined(__OPENCL_VERSION__)


### PR DESCRIPTION
bitcasts.h fails to compile with clang on x86. clang supports x86 Intel intrinsics (such as `_castu32_f32`) but the appropriate header must be included

These intrinsics are defined in `ia32intrin.h` [1] which must be included via `x86intrin.h` [2]

[1] https://clang.llvm.org/doxygen/ia32intrin_8h.html#a856b4d4dc3e7300cce3277ac12368687
[2] https://clang.llvm.org/doxygen/ia32intrin_8h_source.html