### PR TITLE
Add RISC-V QEMU test coverage

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -86,6 +86,21 @@ jobs:
         run: cmake --build build --parallel
       - name: Test
         run: ctest --test-dir build --parallel --output-on-failure
+  cmake-linux-riscv64:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - name: Update apt
+        run: sudo apt update
+      - name: Install RISC-V toolchain, QEMU, and Ninja
+        run: sudo apt install ninja-build g++-riscv64-linux-gnu qemu-user-static
+      - name: Configure
+        run: cmake -Bbuild -S. -G Ninja -DCMAKE_BUILD_TYPE=Release -DFP16_BUILD_BENCHMARKS=OFF -DFP16_BUILD_COMPARATIVE_BENCHMARKS=OFF -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_PROCESSOR=riscv64 -DCMAKE_C_COMPILER=riscv64-linux-gnu-gcc -DCMAKE_CXX_COMPILER=riscv64-linux-gnu-g++ "-DCMAKE_CROSSCOMPILING_EMULATOR=qemu-riscv64-static;-L;/usr/riscv64-linux-gnu"
+      - name: Build
+        run: cmake --build build --parallel
+      - name: Test
+        run: ctest --test-dir build --output-on-failure
   cmake-macos-x86_64:
     runs-on: macos-12
     timeout-minutes: 15

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Header-only library for conversion to/from half-precision floating point formats
 - Header-only library, no installation or build required
 - Compatible with C99 and C++11
 - Fully covered with unit tests and microbenchmarks
+- GitHub Actions CI also cross-compiles and runs the unit tests for `riscv64` Linux under QEMU
 
 ## Acknowledgements
 


### PR DESCRIPTION
## Why

`FP16` already has a portable scalar implementation for its conversion routines, and the existing architecture-specific fast paths are optional optimizations rather than hard requirements.

For this project, the missing part is official `riscv64` verification coverage:

- the current code already falls back to a conservative non-native path when `F16C`, AArch64 FP16, and related native conversion options are unavailable;
- that conservative path can be built for `riscv64` today, but upstream CI did not exercise it;
- without a real cross-compiled `riscv64` test run, the portability claim stays weaker than it needs to be.

This patch keeps the conversion logic unchanged and adds a reproducible `riscv64` Linux + QEMU test path to the existing CMake workflow.

## What changed

- Updated `.github/workflows/cmake.yml`:
  - add a `cmake-linux-riscv64` job on `ubuntu-24.04`;
  - install `g++-riscv64-linux-gnu`, `qemu-user-static`, and `ninja-build`;
  - configure CMake for `riscv64` cross-compilation with `CMAKE_CROSSCOMPILING_EMULATOR`;
  - build and run the full unit-test suite under `qemu-riscv64-static`;
  - disable benchmarks in the `riscv64` job to keep the job focused on correctness and runtime manageable.
- Updated `README.md`:
  - document that GitHub Actions CI also cross-compiles and runs the unit tests for `riscv64` Linux under QEMU.

## Verification

- Verified native configure/build/test on the Windows host:
  - `cmake -S . -B build-native -G Ninja -DCMAKE_BUILD_TYPE=Release -DFP16_BUILD_BENCHMARKS=OFF -DFP16_BUILD_COMPARATIVE_BENCHMARKS=OFF`
  - `cmake --build build-native --parallel 4`
  - `ctest --test-dir build-native --output-on-failure`
  - result: `7/7` tests passed.
- Verified the conservative RISC-V macro path:
  - forced `__riscv=1` / `__riscv_xlen=64` compile probe against `include/fp16/macros.h` and `include/fp16/fp16.h`;
  - confirmed `FP16_USE_NATIVE_CONVERSION == 0`, `FP16_USE_FLOAT16_TYPE == 0`, and `FP16_USE_FP16_TYPE == 0` on the conservative RISC-V path.
- Verified real `riscv64` Linux cross-compilation and QEMU execution in Docker (`ubuntu:24.04`):
  - configured CMake with `riscv64-linux-gnu-gcc`, `riscv64-linux-gnu-g++`, `CMAKE_SYSTEM_PROCESSOR=riscv64`, and `CMAKE_CROSSCOMPILING_EMULATOR=qemu-riscv64-static;-L;/usr/riscv64-linux-gnu`;
  - built the test suite successfully;
  - ran the full `ctest` suite under QEMU with no failures.
- Verified the completed QEMU run from CTest logs:
  - `Start testing: Jun 18 13:43 UTC`
  - `End testing: Jun 18 14:00 UTC`
  - `PassedCount = 7`
  - `FailedCount = 0`
  - `LastTest.log` confirms execution through `qemu-riscv64-static`.
- Verified the cross build configuration:
  - `build-riscv/CMakeCache.txt` records `CMAKE_C_COMPILER=/usr/bin/riscv64-linux-gnu-gcc`
  - `CMAKE_CXX_COMPILER=/usr/bin/riscv64-linux-gnu-g++`
  - `CMAKE_SYSTEM_PROCESSOR=riscv64`
  - `CMAKE_CROSSCOMPILING_EMULATOR=qemu-riscv64-static;-L;/usr/riscv64-linux-gnu`
- Verified the workflow file parses as valid YAML.

## Notes

- This patch does not change the FP16 conversion algorithms or add a RISC-V-specific optimized backend.
- The goal is to make the already-portable scalar path officially verified for `riscv64`, not to claim new architecture-specific acceleration.